### PR TITLE
Add a margin between header and chart on small screens

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -982,7 +982,7 @@ footer a:hover {
 
   .chart-section {
     width: 95%;
-    margin: 0 auto;
+    margin: 2rem auto;
   }
 
   .chart-container {


### PR DESCRIPTION
Before:
<img width="652" height="92" alt="image" src="https://github.com/user-attachments/assets/cfcd52c2-c262-48bc-ab3b-48ae8ceac7a0" />

After, applying the same margin as for big screens:

<img width="646" height="197" alt="image" src="https://github.com/user-attachments/assets/6d02bd23-b33c-4d7e-b083-6cbf9008645b" />
