### PR TITLE
🐛 Use noon to fix timezones from messing up chart

### DIFF
--- a/frontend/src/components/DetailView.tsx
+++ b/frontend/src/components/DetailView.tsx
@@ -165,8 +165,9 @@ const DetailView: Component<DetailViewProps> = (props) => {
   };
 
   const formatDate = (dateStr: string) => {
-    // Use noon to avoid timezone issues (midnight UTC shows as previous day in US timezones)
-    return new Date(dateStr.split('T')[0] + 'T12:00:00').toLocaleDateString('en-US', {
+    // Parse as UTC to avoid timezone issues
+    return new Date(dateStr.split('T')[0] + 'T00:00:00Z').toLocaleDateString('en-US', {
+      timeZone: 'UTC',
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/frontend/src/components/PerformanceChart.tsx
+++ b/frontend/src/components/PerformanceChart.tsx
@@ -362,12 +362,12 @@ const PerformanceChart: Component<PerformanceChartProps> = (props) => {
     return props.data
       .filter(r => r.is_jit && r.speedup !== null && r.speedup !== undefined)
       .map(r => {
-        // Use noon to avoid timezone issues (midnight UTC shows as previous day in US timezones)
-        const parsedDate = new Date(r.date.split('T')[0] + 'T12:00:00');
+        const parsedDate = new Date(r.date.split('T')[0] + 'T00:00:00Z');
+        const dateStr = parsedDate.toISOString().split('T')[0];
         return {
           ...r,
           parsedDate,
-          dateStr: parsedDate.toISOString().split('T')[0],
+          dateStr,
         };
       }) as ParsedRun[];
   });
@@ -407,8 +407,8 @@ const PerformanceChart: Component<PerformanceChartProps> = (props) => {
           // Fallback: use x value date
           const point = data.points[0];
           if (point.x) {
-            // Use noon to avoid timezone issues
-            const dateStr = new Date(String(point.x).split('T')[0] + 'T12:00:00').toISOString().split('T')[0];
+            // Parse as UTC to avoid timezone issues
+            const dateStr = new Date(String(point.x).split('T')[0] + 'T00:00:00Z').toISOString().split('T')[0];
             onPointClick(dateStr);
           }
         }


### PR DESCRIPTION
Closes #18

Ah ha! It's timezones! We need to explicitly parse and display as UTC to fix this from converting to user's local timezone.