### PR TITLE
Add sulaco benchmark machine

### DIFF
--- a/api/sources.yaml
+++ b/api/sources.yaml
@@ -24,3 +24,14 @@ sources:
         os: "Windows 11 Pro"
         arch: "x86_64"
         color: "#ec4899"
+  - repo: "diegorusso/pyperf-bench"
+    owner: "Diego Russo"
+    owner_email: "diego@python.org"
+    fork_filter: "python"
+    machines:
+      blueberry:
+      sulaco:
+        description: "AmpereOne Arm v8.6, 192 cores @ 3.6GHz, 512GB RAM"
+        os: "Ubuntu 24.04"
+        arch: "aarch64"
+        color: "#f59e0b"

--- a/api/sources.yaml
+++ b/api/sources.yaml
@@ -29,7 +29,6 @@ sources:
     owner_email: "diego@python.org"
     fork_filter: "python"
     machines:
-      blueberry:
       sulaco:
         description: "AmpereOne Arm v8.6, 192 cores @ 3.6GHz, 512GB RAM"
         os: "Ubuntu 24.04"


### PR DESCRIPTION
## Adding a new benchmark machine

> **Note:** This template is for contributing new benchmark machines. If your PR is for something else (bug fix, docs, etc.), feel free to clear this template and describe your changes instead.

### Nightly workflow run
<!-- Link to a successful run of your nightly benchmark job -->
https://github.com/diegorusso/pyperf-bench/actions/runs/25088166601

### Contact
- **Discord handle:** `diego.russo`

### Hardware and environment checklist
- [x] This machine is dedicated to running benchmarks (not a shared workstation, CI runner, etc.)
- [x] I have taken steps to minimize system noise (disabled unnecessary services, background updates, turbo boost/frequency scaling where possible)
- [x] Benchmarks are run using [bench_runner](https://github.com/faster-cpython/bench_runner) and results follow the expected directory naming convention
- [x] My nightly workflow reads from [commit.txt](https://github.com/savannahostrowski/pyperf_bench/blob/main/commit.txt) to benchmark the same CPython commit as other machines
- [x] I have at least a few days of benchmark results in my results repo

### Maintenance commitment
- [x] I commit to keeping this machine running nightly benchmarks and investigating anomalous results
- [x] I understand that machines may be removed from the dashboard if they are consistently offline or producing unreliable data without communication
